### PR TITLE
Unicode compatibility: replace index arithmetics by `prevind`

### DIFF
--- a/src/StrLiterals.jl
+++ b/src/StrLiterals.jl
@@ -30,7 +30,7 @@ end
 
 @api develop NEW_ITERATE, str_next
 
-@api develop! interpolated_parse, interpolated_parse_vec, s_parse_unicode, s_parse_legacy, 
+@api develop! interpolated_parse, interpolated_parse_vec, s_parse_unicode, s_parse_legacy,
               s_print_unescaped_legacy, s_print_unescaped, s_print_escaped, s_print,
               s_escape_string, s_unescape_string, s_unescape_str, s_unescape_legacy
 
@@ -233,8 +233,8 @@ function interpolated_parse_vec(s::AbstractString, unescape::Function, flg::Bool
             c = s[k]
             if c == '('
                 # Handle interpolation
-                is_empty(s[i:j-1]) ||
-                    push!(sx, unescape(s[i:j-1]))
+                is_empty(s[i:prevind(s, j)]) ||
+                    push!(sx, unescape(s[i:prevind(s, j)]))
                 ex, j = parse(Expr, s, k, greedy=false)
                 check_expr(ex)
                 push!(sx, esc(ex))
@@ -242,8 +242,8 @@ function interpolated_parse_vec(s::AbstractString, unescape::Function, flg::Bool
             elseif haskey(interpolate, c)
                 i = j = interpolate[c](sx, s, unescape, i, j, k)
             elseif flg && c == '$'
-                is_empty(s[i:j-1]) ||
-                    push!(sx, unescape(s[i:j-1]))
+                is_empty(s[i:prevind(s, j)]) ||
+                    push!(sx, unescape(s[i:prevind(s, j)]))
                 i = k
                 # Move past \\, c should point to '$'
                 c, j = str_next(s, k)
@@ -251,8 +251,8 @@ function interpolated_parse_vec(s::AbstractString, unescape::Function, flg::Bool
                 j = k
             end
         elseif flg && c == '$'
-            is_empty(s[i:j-1]) ||
-                push!(sx, unescape(s[i:j-1]))
+            is_empty(s[i:prevind(s, j)]) ||
+                push!(sx, unescape(s[i:prevind(s, j)]))
             ex, j = parse(Expr, s, k, greedy=false)
             check_expr(ex)
             push!(sx, esc(ex))
@@ -262,7 +262,7 @@ function interpolated_parse_vec(s::AbstractString, unescape::Function, flg::Bool
         end
     end
     is_empty(s[i:end]) ||
-        push!(sx, unescape(s[i:j-1]))
+        push!(sx, unescape(s[i:end]))
     sx
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,3 +121,8 @@ end
     s_print_unescaped(io, f"' \" \\\\ \\u{7f} € 🖖 \\u{e0000}")
     @test ts(io) == "' \" \\ \x7f € 🖖 \Ue0000"
 end
+
+@testset "unicode character preceeding expressions or at the end" begin
+    @test f"π\(2*2)" == "π4"
+    @test f"π = \(2*90)°" == "π = 180°"
+end


### PR DESCRIPTION
There are two cases where unicode characters in f"..." expressions currently fail due to index arithmetics:
- directly preceeding expressions
- at the end of the expression

Replacing `j-1` by prevind(s, j) solves the problem.

I have included two test cases in the `runtest.jl` which currently fail:
```
@test f"π\(2*2)" == "π4"
@test f"π = \(2*90)°" == "π = 180°"
```